### PR TITLE
Clarify "WebID Profile Document"

### DIFF
--- a/index.html
+++ b/index.html
@@ -906,8 +906,12 @@
               </p>
               <p>
                 The discovery process starts with the WebID, a URI that points
-                to exactly one document, referred to here as a WebID Profile
-                Document. This document can be expected to contain pointers to a
+                to exactly one document, referred to here as a <i>Solid WebID Profile
+                Document</i> (note: when this specification uses the phrase "WebID
+                Profile Document" it will always refer to a *Solid* WebID Profile
+                Document, not to WebID Profile Documents used outside a Solid context.)
+                
+                This Solid WebID Profile Document can be expected to contain pointers to a
                 Preferences File Document containing settings &amp; resources
                 meant only for the WebID owner, Type Index Documents containing
                 links to specific types of resources, and might also contain


### PR DESCRIPTION
I added some text to explicitly state that we are not talking about WebID profiles in general (which do not have to behave as Solid resources) but are referring to *Solid* WebID Profile Documents (which are a superset of WebID profiles and, in my opinion, DO need to behave as a Solid resource.)