### PR TITLE
editorial: storage section, 'pod' mentions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1344,7 +1344,7 @@
             <h2 property="schema:name">Storage</h2>
             <div datatype="rdf:HTML" property="schema:description">
               <p>
-                The <code>pim:storage</code> predicate is used to indicate where
+                The <code>pim:storage</code> predicate denotes a storage
                 a WebID owner stores their data. When an application needs to access the
                 WebID owner's storage, it can find its location using the
                 <code>pim:storage</code> predicate.

--- a/index.html
+++ b/index.html
@@ -891,7 +891,7 @@
                 <figcaption property="schema:name">Solid Profile Discovery Overview</figcaption>
               </figure>
               <p>
-                Once an app has loaded all of the needed profile documents, it
+                Once an application has loaded all of the needed profile documents, it
                 can then look for a fixed set of predicates holding information
                 about the structure and location of the WebID owner's resources.
                 The predicates listed below are used throughout this document.
@@ -1170,13 +1170,13 @@
                 by loading documents rather than as a set of documents.
               </p>
 
-              <p>When an app wants to retrieve a complete profile, it SHOULD</p>
+              <p>When an application wants to retrieve a complete profile, it SHOULD</p>
               <ol>
                 <li>
                   Load the WebID Profile Document reachable at the WebID URI.
                 </li>
                 <li>
-                  If the app is operating on behalf of the WebID owner, find a
+                  If the application is operating on behalf of the WebID owner, find a
                   triple in that document with the WebID as subject and
                   pim:preferencesFile as predicate, then load the object of that
                   triple.
@@ -1186,7 +1186,7 @@
                 Once all of the accessible extended profile documents have been
                 loaded, the profile will consist of all statements with the
                 WebID as subject, regardless of which document the statements
-                occurred in. An app with only public permissions will see only
+                occurred in. An application with only public permissions will see only
                 statements from publicly accessible extended profile documents
                 while other apps will see statements from public and also
                 private extended profile documents they have access to.
@@ -1204,14 +1204,14 @@
             <div datatype="rdf:HTML" property="schema:description">
               <p>
                 The Preferences Document is a resource intended to hold
-                information only accessible to an app that is logged in and
+                information only accessible to an application that is logged in and
                 authenticated as the WebID owner or as an agent delegated by the
                 WebID owner to act in their behalf. The preference Document can
                 include settings and preferences, and pointers to the owner's
                 personal, private data, be it contacts, pictures or health data.
-                An app operating on behalf of the owner can gather configuration
+                An application operating on behalf of the owner can gather configuration
                 settings from the owner, store them in the Preferences Document,
-                and then read them there on subsequent visits. Such an app might
+                and then read them there on subsequent visits. Such an application might
                 also record private information (for example, a driver's license
                 number) and later, at the direction of the owner, retrieve the
                 information to fill out a form. A Solid WebID Profile Document
@@ -1221,11 +1221,11 @@
               </p>
               <pre><code>&lt;?WebID&gt; &lt;http://www.w3.org/ns/pim/space#preferencesFile&gt; &lt;?PreferencesDocument&gt; .</code></pre>
               <p>
-                When an app operating on behalf of the WebID owner cannot
+                When an application operating on behalf of the WebID owner cannot
                 discover a <code>pim:preferencesFile</code> triple, and has
                 write and control access, and wishes to write preference data,
                 it could create a document accessible only to the WebID owner.
-                An app that creates a Preference Document can insert a triple in
+                An application that creates a Preference Document can insert a triple in
                 the WebID Profile Document with the WebID as subject,
                 <code>pim:preferencesFile</code> as predicate, and the URL of
                 the created document as object.
@@ -1264,23 +1264,23 @@
                 </h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>
-                    An app wanting to load a complete Solid Profile MUST examine
+                    An application wanting to load a complete Solid Profile MUST examine
                     statements in the WebID Profile Document and the Preferences
                     Document that have the WebID as subject,
                     <code>rdfs:seeAlso</code> as predicate and the URL of an
-                    Extended Profile Document as object. When the app has loaded
+                    Extended Profile Document as object. When the application has loaded
                     those two documents, it SHOULD load the documents specified
                     in the URLs of all <code>rdfs:seeAlso</code> triples found
                     and SHOULD treat all statements in the linked documents that
                     have the WebID as subject as part of the Solid Profile. An
-                    app may but can not be expected to load the objects of
+                    application may but can not be expected to load the objects of
                     <code>rdfs:seeAlso</code> triples found in documents that
                     are themselves the object of an
                     <code>rdfs:seeAlso</code> triple. In other words, look in
                     the WebID Profile Document and in the Preferences Document
                     for <code>rdfs:seeAlso</code> triples but don't necessarily
                     follow any additional <code>rdfs:seeAlso</code> triples
-                    found in those documents. An app can examine any statement
+                    found in those documents. An application can examine any statement
                     found in the linked documents for other purpose, which are
                     not described by this specification.
                   </p>
@@ -1298,7 +1298,7 @@
                 </h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>
-                    When an app wants to write data in an Extended Profile
+                    When an application wants to write data in an Extended Profile
                     Document, it SHOULD give the document appropriate
                     permissions depending on the needs of the WebID owner. If
                     the document is meant only for the WebID owner, the app
@@ -1345,43 +1345,14 @@
             <div datatype="rdf:HTML" property="schema:description">
               <p>
                 The <code>pim:storage</code> predicate is used to indicate where
-                a WebID owner stores their data. An app wanting to access the
-                WebID owner's Pod should find its location using the
-                <code>pim:storage</code> predicate. 
+                a WebID owner stores their data. When an application needs to access the
+                WebID owner's storage, it can find its location using the
+                <code>pim:storage</code> predicate.
               </p>
               <p>
                 A Solid Profile SHOULD contain at least one triple with the
                 WebID as subject, <code>pim:storage</code> as predicate, and the
-                root container of the storage as the object. For example:
-              </p>
-              <pre><code>&lt;?WebID&gt; &lt;http://www.w3.org/ns/pim/space#storage&gt; &lt;?StorageSpace&gt;.</code></pre>
-              <p>
-                If no storage is found within the Solid Profile, an app MAY
-                determine the location of a WebID in the context of a WebID
-                Profile Document hosted on a Solid server as per Solid Protocol
-                0.9, but this method is not guaranteed to be usable by the app
-                in cases where the WebID Profile Document is hosted elsewhere.
-              </p>
-              <p>
-                If no storage space is found through either the profile triples
-                or finding the closest storage, an app MAY prompt the user to
-                find a location to access data.
-              </p>
-              <p>
-                A Pod Management App MAY offer to create a triple by prompting
-                the user for the Pod location and desired discoverability of the
-                Pod. For example, Jose might want their Pod only to store
-                private data and not even let anyone discover that they own the
-                Pod. In that case the app should write the
-                <code>pim:storage</code> triple in the
-                <code>pim:preferencesFile</code> rather than in the WebID
-                Profile Document or a publicly available extended profile
-                document.
-              </p>
-              <p>
-                Applications SHOULD NOT depend on guessing a storage location
-                based on the WebID URI because the WebID Profile Document may or
-                may not be on the same server as the Pod.
+                root container of the storage as the object, but MAY contain more than one.
               </p>
             </div>
           </section>
@@ -1410,7 +1381,7 @@
             <h2 property="schema:name">Other predicates</h2>
             <div datatype="rdf:HTML" property="schema:description">
               <p>
-                A user, a server or an app with appropriate permissions can add
+                A user, a server or an application with appropriate permissions can add
                 triples to profiles using any predicates. This specification
                 covers only those predicates related to resource infrastructure
                 that are in common use at the time of this writing and which we

--- a/index.html
+++ b/index.html
@@ -1345,9 +1345,7 @@
             <div datatype="rdf:HTML" property="schema:description">
               <p>
                 The <code>pim:storage</code> predicate denotes a storage
-                a WebID owner stores their data. When an application needs to access the
-                WebID owner's storage, it can find its location using the
-                <code>pim:storage</code> predicate.
+               available to the agent to use.
               </p>
               <p>
                 A Solid Profile SHOULD contain at least one triple with the

--- a/index.html
+++ b/index.html
@@ -1350,7 +1350,7 @@
               <p>
                 A Solid Profile SHOULD contain at least one triple with the
                 WebID as subject, <code>pim:storage</code> as predicate, and the
-                root container of the storage as the object, but MAY contain more than one.
+                storage as the object.
               </p>
             </div>
           </section>


### PR DESCRIPTION
This PR makes editorial changes, namely:

- Remove recommendations for apps for storage section (see https://github.com/solid/webid-profile/issues/72) and include case for multiple storages. 
- Remove mention of 'pod' in favor of 'storage' throughout document.
- Change 'app' occurrences to full word ('application').

Closes https://github.com/solid/webid-profile/issues/70 
Closes https://github.com/solid/webid-profile/issues/71