### PR TITLE
Fix typo in rdfs namespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -984,7 +984,7 @@
                     </tr>
                     <tr>
                       <td><code>rdfs</code></td>
-                      <td>http://www.w3.org/2000/01/rdf-schema</td>
+                      <td>http://www.w3.org/2000/01/rdf-schema#</td>
                       <td>
                         [<cite
                           ><a class="bibref" href="#bib-rdf-schema"


### PR DESCRIPTION
There was a missing hash (`#`) in `rdfs` namespace

`http://www.w3.org/2000/01/rdf-schema` -> `http://www.w3.org/2000/01/rdf-schema#`

_I'm not a member of CG, so if that's an issue, feel free to close this, and fix in other PR (i don't need credit for this 🤷🏾‍♀️)_