### PR TITLE
Feat: update HTTP refs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1488,7 +1488,7 @@
                         href="https://www.rfc-editor.org/rfc/rfc9110"
                         rel="cito:citesAsAuthority"
                         ><cite>HTTP Semantics</cite></a
-                      >. R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. IETF. June 2022.
+                      >. R. Fielding, M. Nottingham, J. Reschke, Editors. IETF. June 2022.
                       Internet Standard. URL:
                       <a href="https://www.rfc-editor.org/rfc/rfc9110"
                         >https://www.rfc-editor.org/rfc/rfc9110</a
@@ -1500,7 +1500,7 @@
                         href="https://www.rfc-editor.org/rfc/rfc9112"
                         rel="cito:citesAsAuthority"
                         ><cite>HTTP/1.1</cite></a
-                      >. R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. IETF. June 2022.
+                      >. R. Fielding, M. Nottingham, J. Reschke, Editors. IETF. June 2022.
                       Internet Standard. URL:
                       <a href="https://www.rfc-editor.org/rfc/rfc9112"
                         >https://www.rfc-editor.org/rfc/rfc9112</a

--- a/index.html
+++ b/index.html
@@ -1468,6 +1468,20 @@
                         >https://datatracker.ietf.org/doc/html/rfc6454</a
                       >
                     </dd>
+                    <dt id="bib-rfc8174">[RFC8174]</dt>
+                    <dd>
+                      <a
+                        href="https://datatracker.ietf.org/doc/html/rfc8174"
+                        rel="cito:citesAsAuthority"
+                        ><cite
+                          >Ambiguity of Uppercase vs Lowercase in RFC 2119 Key
+                          Words</cite
+                        ></a
+                      >. B. Leiba. IETF. May 2017. Best Current Practice. URL:
+                      <a href="https://datatracker.ietf.org/doc/html/rfc8174"
+                        >https://datatracker.ietf.org/doc/html/rfc8174</a
+                      >
+                    </dd>
                     <dt id="bib-rfc9110">[RFC9110]</dt>
                     <dd>
                       <a
@@ -1490,20 +1504,6 @@
                       Internet Standard. URL:
                       <a href="https://www.rfc-editor.org/rfc/rfc9112"
                         >https://www.rfc-editor.org/rfc/rfc9112</a
-                      >
-                    </dd>
-                    <dt id="bib-rfc8174">[RFC8174]</dt>
-                    <dd>
-                      <a
-                        href="https://datatracker.ietf.org/doc/html/rfc8174"
-                        rel="cito:citesAsAuthority"
-                        ><cite
-                          >Ambiguity of Uppercase vs Lowercase in RFC 2119 Key
-                          Words</cite
-                        ></a
-                      >. B. Leiba. IETF. May 2017. Best Current Practice. URL:
-                      <a href="https://datatracker.ietf.org/doc/html/rfc8174"
-                        >https://datatracker.ietf.org/doc/html/rfc8174</a
                       >
                     </dd>
                     <dt id="bib-solid-oidc">[SOLID-OIDC]</dt>

--- a/index.html
+++ b/index.html
@@ -1468,34 +1468,28 @@
                         >https://datatracker.ietf.org/doc/html/rfc6454</a
                       >
                     </dd>
-                    <dt id="bib-rfc7230">[RFC7230]</dt>
+                    <dt id="bib-rfc9110">[RFC9110]</dt>
                     <dd>
                       <a
-                        href="https://httpwg.org/specs/rfc7230.html"
+                        href="https://www.rfc-editor.org/rfc/rfc9110"
                         rel="cito:citesAsAuthority"
-                        ><cite
-                          >Hypertext Transfer Protocol (HTTP/1.1): Message
-                          Syntax and Routing</cite
-                        ></a
-                      >. R. Fielding, Ed.; J. Reschke, Ed.. IETF. June 2014.
-                      Proposed Standard. URL:
-                      <a href="https://httpwg.org/specs/rfc7230.html"
-                        >https://httpwg.org/specs/rfc7230.html</a
+                        ><cite>HTTP Semantics</cite></a
+                      >. R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. IETF. June 2022.
+                      Internet Standard. URL:
+                      <a href="https://www.rfc-editor.org/rfc/rfc9110"
+                        >https://www.rfc-editor.org/rfc/rfc9110</a
                       >
                     </dd>
-                    <dt id="bib-rfc7231">[RFC7231]</dt>
+                    <dt id="bib-rfc9112">[RFC9112]</dt>
                     <dd>
                       <a
-                        href="https://httpwg.org/specs/rfc7231.html"
+                        href="https://www.rfc-editor.org/rfc/rfc9112"
                         rel="cito:citesAsAuthority"
-                        ><cite
-                          >Hypertext Transfer Protocol (HTTP/1.1): Semantics and
-                          Content</cite
-                        ></a
-                      >. R. Fielding, Ed.; J. Reschke, Ed.. IETF. June 2014.
-                      Proposed Standard. URL:
-                      <a href="https://httpwg.org/specs/rfc7231.html"
-                        >https://httpwg.org/specs/rfc7231.html</a
+                        ><cite>HTTP/1.1</cite></a
+                      >. R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. IETF. June 2022.
+                      Internet Standard. URL:
+                      <a href="https://www.rfc-editor.org/rfc/rfc9112"
+                        >https://www.rfc-editor.org/rfc/rfc9112</a
                       >
                     </dd>
                     <dt id="bib-rfc8174">[RFC8174]</dt>


### PR DESCRIPTION
Following up on https://github.com/solid/specification/issues/471, this PR updates the references to HTTP RFCs from 723x to 911x. While these are normative references, this has no impact, since they are not actually used in the draft.

If there still are any concerns about normative changes, you can check the changelogs here:
- [RFC7230 => RFC9112](https://www.rfc-editor.org/rfc/rfc9112#name-changes-from-rfc-7230)
- [RFC7230 => RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2)
- [RFC7231 => RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.3)

Target | Correction class | Note
-- | -- | --
#bib-rfc7230 | [1](https://www.w3.org/2021/Process-20211102/#class-1) (no content change, only bibliography) | removes (unused) reference to obsolete RFC7230
#bib-rfc7231 | [1](https://www.w3.org/2021/Process-20211102/#class-1) (no content change, only bibliography) | removes (unused) reference to obsolete RFC7231
#bib-rfc9110 | [1](https://www.w3.org/2021/Process-20211102/#class-1) (no content change, only bibliography) | inserts (unused) reference to replacing RFC9110
#bib-rfc9112 | [1](https://www.w3.org/2021/Process-20211102/#class-1) (no content change, only bibliography) | inserts (unused) reference to replacing RFC9112

[HTML Preview](https://htmlpreview.github.io/?https://github.com/woutermont/webid-profile/blob/feat/update-http-refs/index.html) | [HTML Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.github.com%2Fsolid%2Fwebid-profile%2Fmain%2Findex.html&doc2=https%3A%2F%2Fraw.github.com%2Fwoutermont%2Fwebid-profile%2Ffeat%2Fupdate-http-refs%2Findex.html)

On a sidenote: do you all manually update the HTML here? Bikeshed or ReSpec are quite handy in keeping track of references, amongst other things.