### PR TITLE
Remove mention of Solid Process from SotD

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,11 +660,8 @@
                 <a href="https://www.w3.org/community/solid/"
                   >Solid Community Group</a
                 >
-                as an <em>Editor’s Draft</em>. The sections that have been
-                incorporated have been reviewed following the
-                <a href="https://github.com/solid/process">Solid process</a>.
-                However, the information in this document is still subject to
-                change. You are invited to
+                as an <em>Editor’s Draft</em>. The information in this document
+                is still subject to change. You are invited to
                 <a href="https://github.com/solid/webid-profile/issues"
                   >contribute</a
                 >


### PR DESCRIPTION
PR updates the SotD section given that the [Solid CG Charter](https://www.w3.org/community/solid/charter/) supersedes Solid Process.