### PR TITLE
WebID can be in either subject or object position in statements describing it.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1105,7 +1105,7 @@
                 <li><a href="https://solid.github.io/type-indexes/">Type Index Documents</a>, containing links to specific resource types.</li>
                 <li><a href="#extended-profile">Extended Profile Documents</a>, containing supplementary information about the WebID owner.</li>
               </ul>
-              <p>A profile can be compiled by reading all statements with the WebID as the subject or the object, regardless of their originating
+              <p>A profile can be assembled by collecting all statements that have the WebID as the subject or the object, regardless of their originating
                 documents, as illustrated below.</p>
               <figure id="solid-profile-discovery-overview" rel="schema:hasPart" resource="#solid-profile-discovery-overview">
                 <img src="profile-discovery.png" rel="schema:image" />

--- a/index.html
+++ b/index.html
@@ -1105,7 +1105,7 @@
                 <li><a href="https://solid.github.io/type-indexes/">Type Index Documents</a>, containing links to specific resource types.</li>
                 <li><a href="#extended-profile">Extended Profile Documents</a>, containing supplementary information about the WebID owner.</li>
               </ul>
-              <p>A profile can be compiled by reading all statements with the WebID as the subject, regardless of their originating
+              <p>A profile can be compiled by reading all statements with the WebID as the subject or the object, regardless of their originating
                 documents, as illustrated below.</p>
               <figure id="solid-profile-discovery-overview" rel="schema:hasPart" resource="#solid-profile-discovery-overview">
                 <img src="profile-discovery.png" rel="schema:image" />


### PR DESCRIPTION
~The subject or the object position in the statement depends on the direction of the predicate. Predicates can be used in reverse direction, in which case the WebID will appear as the object.~

Please see @TallTed comment and  https://github.com/solid/webid-profile/pull/112#discussion_r1430480629 for a better formulation. 