### PR TITLE
Fix ReaderApplication request header to Accept

### DIFF
--- a/index.html
+++ b/index.html
@@ -1132,8 +1132,8 @@
                   <span property="spec:statement">To retrieve a representation of a Solid WebID Profile, <a
                       rel="spec:requirementSubject" href="#ReaderApplication">Reader Application</a> <span
                       rel="spec:requirementLevel" resource="spec:MUST">MUST</span> make
-                    an HTTP <code>GET</code> request targeting a Solid WebID Profile resource including a
-                    <code>Content-Type</code> header requesting a representation in <code>text/turtle</code> or
+                    an HTTP <code>GET</code> request targeting a Solid WebID Profile resource and include an
+                    <code>Accept</code> header requesting a representation in <code>text/turtle</code> or
                     <code>application/ld+json</code>.</span>
                 </p>
               </div>


### PR DESCRIPTION
For the requirement #reader-application-webid-profile, when the ReaderApplication is using `GET`, the intended header is `Accept` (as opposed to `Content-Type`).

This PR includes "Corrections that do not add new features" ( https://www.w3.org/2023/Process-20231103/#class-3 ) in particular technically:

>makes conforming data, processors, or other conforming agents become non-conforming according to the new version

but since this is more of an error in the spec, it also technically:

>makes non-conforming data, processors, or other agents become conforming.

Which is a good thing.