### PR TITLE
Add meronymous profiles under use cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
                 <li>Connectivity of multiple profiles and cross-context recognition.</li>
                 <li>Cascade of profile information.</li>
                 <li>Persistence and evolution of profiles.</li>
-                <li>Anonymous and pseudonymous profiles.</li>
+                <li>Anonymous, pseudonymous, and meronymous profiles.</li>
                 <li>Self-controlled and third-party-controlled identities.</li>
                 <li>Information for the purpose of verification, authentication, authorization purposes.</li>
                 <li>Compilation of preferences, choices, activities and interactions of an agent.</li>


### PR DESCRIPTION
Proposal to acknowledge meronymous profiles as a separate use case alongside anonymous and pseudonymous proiles.

Background: [Mitigating Barriers to Public Social Interaction with Meronymous Communication](https://arxiv.org/pdf/2402.17847)

>meronymity (from the Greek “mero-”, partial, and “nym”, name), a design paradigm where people can make nuanced decisions around what meronym to reveal about themselves and to whom for specific threads of discussion. A meronym is a trustworthy description of an individual, composed of a number of aspects of their identity (identity signals), that provides pertinent information about them without revealing their identity.

>This approach could offer a solution to the trade-offs between the risks of full anonymity,
such as lack of accountability and negativity, and the constraints of persistent identities in pseudonymity.