### PR TITLE
Update webid-profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@ margin-bottom:0.5rem;
         <div class="head">
           <h1 property="schema:name">Solid WebID Profile</h1>
 
-          <h2>Version <span property="doap:revision">1.0.0</span>, Editor’s Draft, 2024-03-04</h2>
+          <p id="w3c-state"><a href="https://www.w3.org/standards/types/#reports" rel="rdf:type">Draft Community Group Report</a>, <time datetime="2024-05-12T00:00:00Z">12 May 2024</time></p>
 
           <details open="">
             <summary>More details about this document</summary>
@@ -410,11 +410,11 @@ margin-bottom:0.5rem;
             <dt>Modified</dt>
             <dd>
               <time
-                content="2024-03-04T00:00:00Z"
+                content="2024-05-12T00:00:00Z"
                 datatype="xsd:dateTime"
-                datetime="2024-03-04T00:00:00Z"
+                datetime="2024-05-12T00:00:00Z"
                 property="schema:dateModified"
-                >2024-03-04</time
+                >2024-05-12</time
               >
             </dd>
           </dl>
@@ -654,7 +654,7 @@ margin-bottom:0.5rem;
             </dl>
           </details>
 
-        <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2022-2024 the Contributors to Solid WebID Profile specification, published by the <a href="https://www.w3.org/groups/cg/solid/">Solid Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/" rel="schema:license">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. All code snippets are in the public domain, <a href="https://creativecommons.org/public-domain/cc0/" rel="schema:license">CC0</a>.</p>
+          <p class="copyright" rel="dcterms:rights" resource="#document-rights"><span property="dcterms:description"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2022–2024 the Contributors to Solid WebID Profile, Version 1.0.0, published by the <a href="https://www.w3.org/groups/cg/solid/">Solid Community Group</a> under the <a about="" href="https://www.w3.org/community/about/agreements/cla/" rel="schema:license">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.</span></p>
 
           <hr title="Separator for header" />
         </div>
@@ -674,45 +674,8 @@ margin-bottom:0.5rem;
 
           <section id="sotd" inlist="" rel="schema:hasPart" resource="#sotd">
             <h2 property="schema:name">Status of This Document</h2>
-            <div property="schema:description" datatype="rdf:HTML">
-              <p>
-                This section describes the status of this document at the time
-                of its publication.
-              </p>
-
-              <p>
-                This document was published by the
-                <a href="https://www.w3.org/community/solid/"
-                  >Solid Community Group</a
-                >
-                as an <em>Editor’s Draft</em>. The information in this document
-                is still subject to change. You are invited to
-                <a href="https://github.com/solid/webid-profile/issues"
-                  >contribute</a
-                >
-                any feedback, comments, or questions you might have.
-              </p>
-
-              <p>
-                Publication as an <em>Editor’s Draft</em> does not imply
-                endorsement by the
-                <abbr title="World Wide Web Consortium">W3C</abbr> Membership.
-                This is a draft document and may be updated, replaced or
-                obsoleted by other documents at any time. It is inappropriate to
-                cite this document as other than work in progress.
-              </p>
-
-              <p>
-                This document was produced by a group operating under the
-                <a href="https://www.w3.org/community/about/agreements/cla/"
-                  >W3C Community Contributor License Agreement (CLA)</a
-                >. A human-readable
-                <a
-                  href="https://www.w3.org/community/about/agreements/cla-deed/"
-                  >summary</a
-                >
-                is available.
-              </p>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>This report was published by the <a href="https://www.w3.org/groups/cg/solid/">Solid Community Group</a>. It is not a W3C Standard nor is it on the W3C Standards Track. Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply. Learn more about <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.</p>
             </div>
           </section>
 


### PR DESCRIPTION
Updates Solid WebID Profile, Version 1.0.0. Publishes:

* This version: https://github.com/solid/webid-profile/ (update)

"This version" is a request to be published as a CG-DRAFT report of the Solid CG.

---

Solid WebID Profile has only one document type at the moment. Whereas Solid Protocol, Solid Notifications Protocol, Web Access Control have separate documents for "published" and "editor's drafts".

If the group wants to do something similar, i.e., https://github.com/solid/webid-profile/ as an editor's draft, and https://solidproject.org/TR/webid-profile as a CG-DRAFT, we can do that too.

The Preview below shows the proposed latest state for CG-DRAFT Report. The Diff shows the changes made towards CG-DRAFT. (The rest of the recent changes towards it was made in https://github.com/solid/webid-profile/pull/116 ).

---

[Preview](https://htmlpreview.github.io/?https://github.com/solid/webid-profile/blob/54e7242b51646e8ee68f69e09dbdfc9e1e0fde10/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fwebid-profile%2F7205cb732d837bbcbaaf7a9b184112831a5f4fe6%2Findex.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fwebid-profile%2F54e7242b51646e8ee68f69e09dbdfc9e1e0fde10%2Findex.html)
