### PR TITLE
Add Proxy section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1292,6 +1292,8 @@ margin-bottom:0.5rem;
               <p>One way for applications to practically bypass this limitation in some situations is by using a trusted or preferred proxy. An application can discover a resource's advertised proxy via the <code>solid:proxy</code> property. While any resource, such as a storage, could advertise a proxy, applications can also discover an agent's preferred proxy by checking this property in their WebID Profile Document.</p>
 
               <p>Additionally, using a proxy allows applications to mask their <code>Origin</code>, enhancing privacy and security during requests. This capability can further protect user data in decentralised environments, though it may not fully address all related challenges on its own.</p>
+
+              <p>An agent's preferred or trusted proxy may not align with their application's. The decision of whether and in what contexts to use any proxy is an evaluation and a balance between the needs of the agent and the application.</p>
             </div>
           </section>
 

--- a/index.html
+++ b/index.html
@@ -776,8 +776,14 @@ margin-bottom:0.5rem;
                   >
                 </li>
                 <li class="tocline">
-                  <a class="tocxref" href="#other-predicates"
+                  <a class="tocxref" href="#proxy"
                     ><bdi class="secno">7.</bdi>
+                    <span>Proxy</span></a
+                  >
+                </li>
+                <li class="tocline">
+                  <a class="tocxref" href="#other-predicates"
+                    ><bdi class="secno">8.</bdi>
                     <span>Other predicates</span></a
                   >
                 </li>
@@ -1278,8 +1284,19 @@ margin-bottom:0.5rem;
             </div>
           </section>
 
+          <section id="proxy" inlist="" rel="schema:hasPart" resource="#proxy"><a class="self-link" href="#proxy"></a>
+            <h2><bdi class="secno">7.</bdi> <span property="schema:name">Proxy</span></h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>When an application needs to make a Cross-Origin Resource Sharing (<abbr title="Cross-Origin Resource Sharing">CORS</abbr>) request using the <cite><a href="https://fetch.spec.whatwg.org/#cors-protocol" rel="cito:citesAsAuthority">CORS protocol</a></cite> [<cite><a class="bibref" href="#bib-fetch">FETCH</a></cite>], the recipient server may not participate in CORS or may often be improperly configured for it. This poses challenges for interoperability in environments like Solid.</p>
+
+              <p>One way for applications to practically bypass this limitation in some situations is by using a trusted or preferred proxy. An application can discover a resource's advertised proxy via the <code>solid:proxy</code> property. While any resource, such as a storage, could advertise a proxy, applications can also discover an agent's preferred proxy by checking this property in their WebID Profile Document.</p>
+
+              <p>Additionally, using a proxy allows applications to mask their <code>Origin</code>, enhancing privacy and security during requests. This capability can further protect user data in decentralised environments, though it may not fully address all related challenges on its own.</p>
+            </div>
+          </section>
+
           <section id="other-predicates" inlist="" rel="schema:hasPart" resource="#other-predicates"><a class="self-link" href="#other-predicates"></a>
-            <h2><bdi class="secno">7.</bdi> <span property="schema:name">Other predicates</span></h2>
+            <h2><bdi class="secno">8.</bdi> <span property="schema:name">Other predicates</span></h2>
             <div datatype="rdf:HTML" property="schema:description">
               <p>
                 A user, a server or an application with appropriate permissions can add

--- a/index.html
+++ b/index.html
@@ -1294,6 +1294,13 @@ margin-bottom:0.5rem;
               <p>Additionally, using a proxy allows applications to mask their <code>Origin</code>, enhancing privacy and security during requests. This capability can further protect user data in decentralised environments, though it may not fully address all related challenges on its own.</p>
 
               <p>An agent's preferred or trusted proxy may not align with their application's. The decision of whether and in what contexts to use any proxy is an evaluation and a balance between the needs of the agent and the application.</p>
+
+              <div class="note" id="proxy-protected" inlist="" rel="schema:hasPart" resource="#proxy-protected"><a class="self-link" href="#proxy-protected"></a>
+                <h3 property="schema:name"><span>Note</span>:</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>It is strongly encouraged to use protected proxies due to potential risks, including data exposure, privacy loss, and response manipulation.</p>
+                </div>
+              </div>
             </div>
           </section>
 


### PR DESCRIPTION
Adds a section for Proxy.

Touched by the following use cases mentioned in https://solid.github.io/webid-profile/#use-cases :

* Communication and use of multiple profiles for different purposes.
* Anonymous, pseudonymous, and meronymous profiles.
* Compilation of preferences, choices, activities and interactions of an agent.

See also https://github.com/solid/vocab/pull/94 for adding `solid:proxy` to Solid Terms.

---

[Preview](http://htmlpreview.github.io/?https://github.com/solid/webid-profile/blob/809ed7cd0843928365b58caebbdc299e45b81d18/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fwebid-profile%2Fec1becabc31d569eba1bb8c331e54209b150db20%2Findex.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fwebid-profile%2F809ed7cd0843928365b58caebbdc299e45b81d18%2Findex.html)