### PR TITLE
Require `pim:storage` predicate if WebID is in agent's storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1107,7 +1107,7 @@ margin-bottom:0.5rem;
                     <li>One <code>rdf:type</code> property whose object is <code>foaf:Agent</code>.</li>
                     <li>One <code>pim:preferencesFile</code>.</li>
                     <li>Zero or one <code>ldp:inbox</code>.</li>
-                    <li>Zero or more <code>pim:storage</code> properties to indicate agent's storages.</li>
+                    <li>Zero or more <code>pim:storage</code> properties to indicate agent's storages. If the WebID in an agent's storage, that storage MUST be advertised.</li>
                     <li>Zero or more <code>rdfs:seeAlso</code> to refer to related <a href="#extended-profile-documents">documents
                         extending the profile.</a></li>
                   </ul>


### PR DESCRIPTION
Following the discussion in https://github.com/solid/specification/pull/772 - this PR requires that WebID's conforming to the Solid WebID profile use `pim:storage` to advertise the storage in which a WebID is contained, if the WebID is contained in Solid Storage.

The goal of this is to prevent the majority of client applications from needing to implement discovery of storages using link headers.