### PR TITLE
Fix non-standard predicate in profile discovery shape

### DIFF
--- a/shapes/profile-discovery-shape.ttl
+++ b/shapes/profile-discovery-shape.ttl
@@ -13,7 +13,7 @@
 # SHAPE FOR DISCOVERY OF THE MAJOR ENDPOINTS IN A SOLID WEBID-PROFILE
 #
 # The shape is agnostic as to whether the WebID document is located
-# on a Solid server or not, whether the WebID document and the "social profile"
+# on a Solid server, and whether or not the WebID document and the "social profile"
 # are the same document or not.
 # 
 # To use this shape for validation, one must first load the full profile,

--- a/shapes/profile-discovery-shape.ttl
+++ b/shapes/profile-discovery-shape.ttl
@@ -12,7 +12,7 @@
 #
 # SHAPE FOR DISCOVERY OF THE MAJOR ENDPOINTS IN A SOLID WEBID-PROFILE
 #
-# The shape is agnostic as to whether the WebID document is located
+# The shape is agnostic as to whether or not the WebID document is located
 # on a Solid server, and whether or not the WebID document and the "social profile"
 # are the same document or not.
 # 

--- a/shapes/profile-discovery-shape.ttl
+++ b/shapes/profile-discovery-shape.ttl
@@ -12,19 +12,9 @@
 #
 # SHAPE FOR DISCOVERY OF THE MAJOR ENDPOINTS IN A SOLID WEBID-PROFILE
 #
-# This shape includes discovery predicates mentioned in
-# the Solid WebID Profile draft specification. The intent
-# is to support most currently extant Solid Profiles. Therefore, 
-# this shape includes discovery predicates in common use but not
-# in the draft specification. These include the following:
-#
-#   * the non-standard `foaf:isPrimaryTopicOf`
-#   * the most common validation endpoint — `solid:oidcIssuer`
-
 # The shape is agnostic as to whether the WebID document is located
 # on a Solid server or not, whether the WebID document and the "social profile"
-# are the same document or not, and whether the profile uses type indexes
-# or SAI for further discovery.
+# are the same document or not.
 # 
 # To use this shape for validation, one must first load the full profile,
 # i.e., all of the available endpoints in the shape.  The resulting graph

--- a/shapes/profile-discovery-shape.ttl
+++ b/shapes/profile-discovery-shape.ttl
@@ -18,10 +18,9 @@
 # this shape includes discovery predicates in common use but not
 # in the draft specification. These include the following:
 #
-#   * the non-standard `foaf:primaryTopicOf`
+#   * the non-standard `foaf:isPrimaryTopicOf`
 #   * the most common validation endpoint — `solid:oidcIssuer`
-#   * both discovery mechanisms in current use — type indexes and SAI
-# 
+
 # The shape is agnostic as to whether the WebID document is located
 # on a Solid server or not, whether the WebID document and the "social profile"
 # are the same document or not, and whether the profile uses type indexes

--- a/shapes/profile-discovery-shape.ttl
+++ b/shapes/profile-discovery-shape.ttl
@@ -14,7 +14,7 @@
 #
 # The shape is agnostic as to whether or not the WebID document is located
 # on a Solid server, and whether or not the WebID document and the "social profile"
-# are the same document or not.
+# are the same document.
 # 
 # To use this shape for validation, one must first load the full profile,
 # i.e., all of the available endpoints in the shape.  The resulting graph


### PR DESCRIPTION
Corrected the non-standard predicate from `foaf:primaryTopicOf` to `foaf:isPrimaryTopicOf`.