### PR TITLE
Add Privacy and Security Considerations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,6 +782,12 @@ margin-bottom:0.5rem;
                   >
                 </li>
                 <li class="tocline">
+                  <a class="tocxref" href="#privacy-and-security-considerations"
+                    ><bdi class="secno">8.</bdi>
+                    <span>Privacy and Security Considerations</span></a
+                  >
+                </li>
+                <li class="tocline">
                   <a class="tocxref" href="#changelog"><bdi class="secno">A.</bdi> <span>Changelog</span></a>
                 </li>
                 <li class="tocline">
@@ -1292,6 +1298,25 @@ margin-bottom:0.5rem;
                 working on proposals which will add additional infrastructure
                 related predicates to Solid profiles.
               </p>
+            </div>
+          </section>
+
+          <section id="privacy-and-security-considerations" inlist="" rel="schema:hasPart" resource="#privacy-and-security-considerations"><a class="self-link" href="#privacy-and-security-considerations"></a>
+            <h2><bdi class="secno">8.</bdi> <span property="schema:name">Privacy and Security Considerations</span></h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p><em>This section is non-normative.</em></p>
+
+              <section id="impact-of-not-enforcing-protected-properties" inlist="" rel="schema:hasPart" resource="#impact-of-not-enforcing-protected-properties">
+                <h3>Impact of not enforcing Protected Properties</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The <a href="#protected-properties">Protected Properties</a> requirement is intended to prevent agents other than the WebID owner from modifying specific properties, notably <code>solid:oidcIssuer</code>. When a Solid server does not enforce these protections, the WebID Profile is open to attack:</p>
+                  <ul>
+                    <li>An agent with write access to the WebID Document can rewrite <code>solid:oidcIssuer</code>, redirecting Solid-OIDC authentication to an attacker-controlled OpenID Provider and impersonating the WebID owner.</li>
+                    <li>Other Protected Properties may be similarly tampered with by an agent granted write access, depending on which properties a particular server fails to protect.</li>
+                  </ul>
+                  <p>Implementations of Solid WebID Profile clients should not assume that a hosted WebID Document's Protected Properties have been preserved as the WebID owner intended; clients reading these properties should weigh the trust they place in the hosting server.</p>
+                </div>
+              </section>
             </div>
           </section>
 

--- a/index.html
+++ b/index.html
@@ -786,6 +786,14 @@ margin-bottom:0.5rem;
                     ><bdi class="secno">8.</bdi>
                     <span>Privacy and Security Considerations</span></a
                   >
+                  <ol>
+                    <li class="tocline">
+                      <a class="tocxref" href="#impact-of-not-enforcing-protected-properties"
+                        ><bdi class="secno">8.1</bdi>
+                        <span>Impact of not enforcing Protected Properties</span></a
+                      >
+                    </li>
+                  </ol>
                 </li>
                 <li class="tocline">
                   <a class="tocxref" href="#changelog"><bdi class="secno">A.</bdi> <span>Changelog</span></a>
@@ -1306,8 +1314,8 @@ margin-bottom:0.5rem;
             <div datatype="rdf:HTML" property="schema:description">
               <p><em>This section is non-normative.</em></p>
 
-              <section id="impact-of-not-enforcing-protected-properties" inlist="" rel="schema:hasPart" resource="#impact-of-not-enforcing-protected-properties">
-                <h3>Impact of not enforcing Protected Properties</h3>
+              <section id="impact-of-not-enforcing-protected-properties" inlist="" rel="schema:hasPart" resource="#impact-of-not-enforcing-protected-properties"><a class="self-link" href="#impact-of-not-enforcing-protected-properties"></a>
+                <h3><bdi class="secno">8.1</bdi> <span property="schema:name">Impact of not enforcing Protected Properties</span></h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>The <a href="#protected-properties">Protected Properties</a> requirement is intended to prevent agents other than the WebID owner from modifying specific properties, notably <code>solid:oidcIssuer</code>. When a Solid server does not enforce these protections, the WebID Profile is open to attack:</p>
                   <ul>

--- a/index.html
+++ b/index.html
@@ -1322,7 +1322,6 @@ margin-bottom:0.5rem;
                     <li>An agent with write access to the WebID Document can rewrite <code>solid:oidcIssuer</code>, redirecting Solid-OIDC authentication to an attacker-controlled OpenID Provider and impersonating the WebID owner.</li>
                     <li>Other Protected Properties may be similarly tampered with by an agent granted write access, depending on which properties a particular server fails to protect.</li>
                   </ul>
-                  <p>Implementations of Solid WebID Profile clients should not assume that a hosted WebID Document's Protected Properties have been preserved as the WebID owner intended; clients reading these properties should weigh the trust they place in the hosting server.</p>
                 </div>
               </section>
             </div>


### PR DESCRIPTION
A preview link can be found [here](https://htmlpreview.github.io/?https://github.com/solid/webid-profile/blob/feat/privacy-security-considerations/index.html).

## Summary

Adds a new §8 *Privacy and Security Considerations* section (non-normative) with one subsection: *Impact of not enforcing Protected Properties*. The Solid WebID Profile draft currently does not include any Privacy or Security Considerations section.

## Why

The [Protected Properties](https://solid.github.io/webid-profile/#protected-properties) requirement is intended to prevent agents other than the WebID owner from modifying properties such as `solid:oidcIssuer`. Most server implementations do not currently enforce this. The new subsection makes the consequences of non-enforcement explicit:

- An agent with write access to the WebID Document can rewrite `solid:oidcIssuer`, redirecting Solid-OIDC authentication to an attacker-controlled OpenID Provider and impersonating the WebID owner.
- Other Protected Properties may be similarly tampered with, depending on which properties a particular server fails to protect.
- Clients reading these properties should weigh the trust they place in the hosting server.

The same point has been added downstream to solid26 §2.5 in [solid/specification#776](https://github.com/solid/specification/pull/776), but the upstream home for considerations of this kind is here.

## Scope

Deliberately narrow — one subsection on Protected Properties non-enforcement. Further considerations (e.g. trust in hosting server beyond Protected Properties, public dereferencing implications) can be added as follow-up PRs.

## Test plan

- [x] Render `index.html` and confirm §8 *Privacy and Security Considerations* appears between §7 *Other predicates* and the Changelog appendix.
- [x] TOC shows §8 entry.
- [x] Internal anchors (`#privacy-and-security-considerations`, `#impact-of-not-enforcing-protected-properties`, `#protected-properties`) resolve.