### PR TITLE
Add §2.1 Assembling the Profile algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,6 +722,16 @@ margin-bottom:0.5rem;
                       >Discovery</span
                     ></a
                   >
+                  <ol>
+                    <li class="tocline">
+                      <a class="tocxref" href="#assembling-profile"
+                        ><bdi class="secno">2.1</bdi>
+                        <span
+                          >Assembling the Profile</span
+                        ></a
+                      >
+                    </li>
+                  </ol>
                 </li>
                 <li class="tocline">
                   <a href="#reading-writing-profiles"
@@ -1085,6 +1095,45 @@ margin-bottom:0.5rem;
               </div>
             </div>
             </div>
+
+            <section id="assembling-profile" inlist="" rel="schema:hasPart" resource="#assembling-profile"><a class="self-link" href="#assembling-profile"></a>
+              <h3><bdi class="secno">2.1</bdi> <span property="schema:name">Assembling the Profile</span></h3>
+              <div datatype="rdf:HTML" property="schema:description">
+                <p>The <a href="#solid-profile">Solid profile</a> is the set <em>S</em> of statements assembled by the procedure below. The <em>user's WebIDs</em> are the original WebID together with every WebID transitively equated to it via <code>owl:sameAs</code> within <em>S</em>; this set grows as <em>S</em> grows. Apply cycle detection throughout: do not re-fetch a document already retrieved. On <code>401</code>/<code>403</code> with a logged-in user, retry authenticated; missing links are not errors.</p>
+                <ol>
+                  <li><strong>Initialise.</strong> <code>GET</code> the WebID Profile Document for the original WebID. If it cannot be retrieved, surface a clear error. Add its triples to <em>S</em>.</li>
+                  <li><strong>Discovery-link expansion.</strong> For each triple <code>?w ?p ?o</code> in <em>S</em> where <code>?p</code> is a <dfn id="discovery-link">discovery link</dfn> (<code>rdfs:seeAlso</code>, <code>foaf:isPrimaryTopicOf</code>, <code>pim:preferencesFile</code>, or <code>owl:sameAs</code>), <code>?w</code> is one of the user's WebIDs, and <code>?o</code> is a URL whose document has not yet been fetched, <code>GET</code> <code>?o</code> and add its triples to <em>S</em>. Repeat until no new documents are discovered.</li>
+                  <li><strong>Type Indexes.</strong> For each triple in <em>S</em> with predicate <code>solid:publicTypeIndex</code> or <code>solid:privateTypeIndex</code> whose subject is one of the user's WebIDs, <code>GET</code> the document at the object (if not already fetched) and add its triples to <em>S</em>.</li>
+                  <li><strong>Authoritative filter.</strong> Drop every <code>solid:oidcIssuer</code> triple in <em>S</em> that did not originate in a WebID Profile Document; that predicate is authoritative only when sourced there, mirroring the write protection in <a href="#updating-profile">§ Updating Profile</a>.</li>
+                  <li><strong>Subject filter.</strong> Restrict <em>S</em> to triples whose subject or object is one of the user's WebIDs. The result is the <a href="#solid-profile">Solid profile</a>.</li>
+                </ol>
+              </div>
+
+              <div class="note" id="bounded-traversal" inlist="" rel="schema:hasPart" resource="#bounded-traversal"><a class="self-link" href="#bounded-traversal"></a>
+                <h5 property="schema:name"><span>Note</span> (Bounded traversal):</h5>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>Traversal of discovery links is unbounded; clients SHOULD apply cycle detection (no document fetched twice). Clients MAY also consider terminating traversal at a depth or document-count limit appropriate to their environment, to bound fetch cost and protect against pathological link chains.</p>
+                </div>
+              </div>
+
+              <div class="note" id="preferences-leniency" inlist="" rel="schema:hasPart" resource="#preferences-leniency"><a class="self-link" href="#preferences-leniency"></a>
+                <h5 property="schema:name"><span>Note</span> (Preferences leniency):</h5>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>Including <code>pim:preferencesFile</code> in the discovery-link set is intentionally lenient. In practice an agent has a single Preferences Document linked from the original WebID Profile Document; the algorithm tolerates the <code>pim:preferencesFile</code> link appearing in any document already in <em>S</em>, provided its subject is one of the user's WebIDs.</p>
+                </div>
+              </div>
+
+              <div class="note" id="entity-reconciliation" inlist="" rel="schema:hasPart" resource="#entity-reconciliation"><a class="self-link" href="#entity-reconciliation"></a>
+                <h5 property="schema:name"><span>Note</span> (Entity reconciliation):</h5>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The assembled graph may contain triples about more than one of the user's WebIDs. Depending on the client's context, these typically need to be reconciled into a single subject. Two common strategies:</p>
+                  <ul>
+                    <li><strong>Augmentation</strong> — for every triple in which one of the user's WebIDs appears as subject or object, add a parallel triple substituting the original WebID. Non-destructive; original sources are preserved.</li>
+                    <li><strong>Rewriting</strong> — replace every occurrence of any of the user's WebIDs (subject or object) with the original WebID, then delete the <code>owl:sameAs</code> triples.</li>
+                  </ul>
+                </div>
+              </div>
+            </section>
           </section>
 
           <section id="reading-writing-profiles" inlist="" rel="schema:hasPart" resource="#reading-writing-profiles"><a class="self-link" href="#reading-writing-profiles"></a>

--- a/index.html
+++ b/index.html
@@ -1112,7 +1112,7 @@ margin-bottom:0.5rem;
               <div class="note" id="bounded-traversal" inlist="" rel="schema:hasPart" resource="#bounded-traversal"><a class="self-link" href="#bounded-traversal"></a>
                 <h5 property="schema:name"><span>Note</span> (Bounded traversal):</h5>
                 <div datatype="rdf:HTML" property="schema:description">
-                  <p>Traversal of discovery links is unbounded; clients SHOULD apply cycle detection (no document fetched twice). Clients MAY also consider terminating traversal at a depth or document-count limit appropriate to their environment, to bound fetch cost and protect against pathological link chains.</p>
+                  <p>Traversal of discovery links is unbounded. Clients apply cycle detection to avoid re-fetching documents. To ensure that owners of WebIDs hosted outside Solid storage can extend their profile via documents they control, clients follow at least two hops of discovery links from each WebID Profile Document (the document itself, the documents it links, and the documents those link in turn). Beyond two hops, clients can terminate at a depth or document-count limit appropriate to their environment.</p>
                 </div>
               </div>
 


### PR DESCRIPTION
**Preview:** [§2.1 Assembling the Profile](https://htmlpreview.github.io/?https://raw.githubusercontent.com/solid/webid-profile/feat/assembly-algorithm/index.html#assembling-profile)

## Summary

Adds a new §2.1 *Assembling the Profile* under § Discovery, defining the WebID Profile assembly procedure as a set-based fixed point.

- The *user's WebIDs* are the original WebID plus the transitive `owl:sameAs` closure within the working set *S*.
- *Discovery-link expansion* fetches documents reachable via `rdfs:seeAlso`, `foaf:isPrimaryTopicOf`, `pim:preferencesFile`, or `owl:sameAs`, restricted to triples whose subject is one of the user's WebIDs. Repeats until no new documents are discovered.
- *Type Indexes* are fetched from `solid:publicTypeIndex` / `solid:privateTypeIndex` on any user's WebID.
- *Authoritative filter* drops `solid:oidcIssuer` triples that did not originate in a WebID Profile Document, mirroring the write protection in § Updating Profile.
- *Subject filter* restricts the final graph to triples whose subject or object is one of the user's WebIDs.

Three notes follow:

- **Bounded traversal** — cycle detection is required; depth/document-count limits are advisory.
- **Preferences leniency** — `pim:preferencesFile` is followed wherever it appears in *S*, provided its subject is a user WebID.
- **Entity reconciliation** — augmentation vs rewriting strategies for collapsing triples about equated WebIDs onto the original WebID.

## Background

This algorithm mirrors the version proposed in solid/specification#776 (the Solid 2.6 Implementation Guide), where it was reframed iteratively in response to review feedback (notably from @jeff-zucker on bounded traversal and hosting-aware behaviour). Lifting it into webid-profile makes it the canonical specification of the assembly procedure; the Implementation Guide can then defer to this section.

## Test plan

- [ ] Visual review of rendered HTML (TOC entry under §2, new §2.1 section)
- [ ] Confirm anchor IDs (`#assembling-profile`, `#bounded-traversal`, `#preferences-leniency`, `#entity-reconciliation`, `#discovery-link`) do not collide with existing IDs
- [ ] Cross-reference to `#updating-profile` resolves
- [ ] Discuss whether `solid:publicTypeIndex` / `solid:privateTypeIndex` references (currently used without local definition in this document) warrant a non-normative note pointing at the Type Indexes spec

cc @csarven @jeff-zucker @TallTed @elf-pavlik @VirginiaBalseiro for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
